### PR TITLE
Add deprecation notice for the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+UPDATE: Deprecation Notice
+==========================
+
+This version of the Wistia documentation is not maintained and contains old, incorrect, or unsupported information. For up-to-date information on the Wistia documentation please visit [wistia.com/support](https://www.wistia.com/support).
+
 Wistia Documentation
 ====================
 


### PR DESCRIPTION
Hi there,

I just wanted to make a pull request adding a note at the top of the README that the information contained within this documentation is massively outdated, and generally not that useful anymore.

My real request would be for you to remove the repo entirely if possible, to make our lives at Wistia a little easier.

You can follow the currently maintained Wistia documentation here: wistia.com/support (it is not longer maintained via GitHub).

Best,
Jordan